### PR TITLE
🐛 Vercel 빌드 에러 수정 (useSearchParams Suspense)

### DIFF
--- a/app/(main)/report/view/page.tsx
+++ b/app/(main)/report/view/page.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import { useSearchParams, useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, Suspense } from 'react';
 import { getMonthlyReport, MonthlyReportData } from '../actions';
 import { Title, Text, Table, Button, Group, Stack, Card, Center, Loader, Divider, ActionIcon } from '@mantine/core';
 import { IconPrinter, IconArrowLeft } from '@tabler/icons-react';
 
-export default function ReportViewPage() {
+function ReportContent() {
     const searchParams = useSearchParams();
     const router = useRouter();
     const year = Number(searchParams.get('year'));
@@ -142,5 +142,13 @@ export default function ReportViewPage() {
                 }
             `}</style>
         </div>
+    );
+}
+
+export default function ReportViewPage() {
+    return (
+        <Suspense fallback={<Center h="100vh"><Loader color="teal" /></Center>}>
+            <ReportContent />
+        </Suspense>
     );
 }


### PR DESCRIPTION
## 🔧 Problem
모든 PR에서 Vercel 빌드가 실패하고 있었습니다.
- `/report/view` 페이지에서 `useSearchParams()` must be wrapped in a suspense boundary 에러 발생

## 📋 Changes
- `app/(main)/report/view/page.tsx` 수정
  - `useSearchParams()`를 사용하는 로직을 `ReportContent` 컴포넌트로 분리
  - `Suspense` boundary로 감싸서 Next.js 15 요구사항 충족

## ✅ Test Result
- ✅ `npm run build` 성공 (로컬)
- ✅ TypeScript 타입 에러 0건
- ✅ 모든 기존 기능 정상 동작 확인

## 📦 Files Changed
- `app/(main)/report/view/page.tsx`

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)