### PR TITLE
🐛 Vercel 빌드 실패 수정 - useSearchParams Suspense 처리

### DIFF
--- a/app/(main)/report/view/page.tsx
+++ b/app/(main)/report/view/page.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import { useSearchParams, useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, Suspense } from 'react';
 import { getMonthlyReport, MonthlyReportData } from '../actions';
 import { Title, Text, Table, Button, Group, Stack, Card, Center, Loader, Divider, ActionIcon } from '@mantine/core';
 import { IconPrinter, IconArrowLeft } from '@tabler/icons-react';
 
-export default function ReportViewPage() {
+function ReportContent() {
     const searchParams = useSearchParams();
     const router = useRouter();
     const year = Number(searchParams.get('year'));
@@ -142,5 +142,13 @@ export default function ReportViewPage() {
                 }
             `}</style>
         </div>
+    );
+}
+
+export default function ReportViewPage() {
+    return (
+        <Suspense fallback={<Center h="100vh"><Loader color="teal" /></Center>}>
+            <ReportContent />
+        </Suspense>
     );
 }


### PR DESCRIPTION
## 🔧 문제

`/report/view` 페이지에서 Vercel 빌드가 실패했습니다.

**에러 메시지**:
```
⨯ useSearchParams() should be wrapped in a suspense boundary at page "/report/view"
```

Next.js 15에서 `useSearchParams()`는 반드시 Suspense boundary로 감싸야 합니다.

## 📋 변경사항

- `ReportViewPage` 컴포넌트를 `ReportContent`로 분리
- `ReportContent`를 `<Suspense>` boundary로 감쌈
- fallback으로 로딩 상태 제공

## ✅ 테스트 결과

- ✅ `npm run build` 성공 (로컬)
- ✅ TypeScript 타입 에러 0건
- ✅ 모든 기존 기능 정상 동작 확인
- ✅ Vercel 빌드 통과 예상

## 📦 수정 파일

- `app/(main)/report/view/page.tsx`

Closes #43

🤖 Generated with Claude Code