### PR TITLE
🐛 Recharts ResponsiveContainer 경고 수정

### DIFF
--- a/app/(main)/strategy/page.tsx
+++ b/app/(main)/strategy/page.tsx
@@ -218,7 +218,7 @@ export default function StrategyPage() {
                             />
                         ) : (
                             <div style={{ flex: 1, width: '100%', minHeight: 350 }}>
-                                <ResponsiveContainer width="100%" height="100%">
+                                <ResponsiveContainer width="100%" height="100%" minHeight={350}>
                                     <ScatterChart margin={{ top: 20, right: 20, bottom: 20, left: 0 }}>
                                         <CartesianGrid strokeDasharray="3 3" stroke="#373A40" />
                                         <XAxis type="number" dataKey="quantity" name="판매량" stroke="#868E96" unit="개" />

--- a/app/components/SalesTrendGraph.tsx
+++ b/app/components/SalesTrendGraph.tsx
@@ -77,8 +77,8 @@ export function SalesTrendGraph({ data }: SalesTrendGraphProps) {
                 </Box>
             </Group>
 
-            <Box h={250} w="100%" style={{ marginLeft: -20 }}>
-                <ResponsiveContainer width="100%" height="100%">
+            <Box h={250} w="100%" style={{ marginLeft: -20, minHeight: 250 }}>
+                <ResponsiveContainer width="100%" height="100%" minHeight={250}>
                     <AreaChart data={chartData}>
                         <defs>
                             <linearGradient id="colorAmount" x1="0" y1="0" x2="0" y2="1">


### PR DESCRIPTION
## 🔧 변경사항
Recharts의 ResponsiveContainer에서 발생하는 콘솔 경고를 수정했습니다.

### 수정 내용
- `app/components/SalesTrendGraph.tsx`: Box에 minHeight 추가 + ResponsiveContainer에 minHeight={250} 설정
- `app/(main)/strategy/page.tsx`: ResponsiveContainer에 minHeight={350} 설정

## 🐛 해결된 문제
Closes #46

대시보드 접속 시 다음 경고가 발생:
```
The width(-1) and height(-1) of chart should be greater than 0
```

## ✅ 테스트 완료
- [x] `npm run build` 성공
- [x] 모든 페이지(22개) 정상 빌드
- [x] TypeScript 타입 에러 없음
- [x] 콘솔 경고 제거 확인 필요 (런타임 테스트)

## 📦 수정 파일
- `app/components/SalesTrendGraph.tsx`
- `app/(main)/strategy/page.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)